### PR TITLE
LBJ-208 Document the need to configure JPA repository scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Include the library in your `pom.xml`:
 Use `@EnableNakadiProducer` annotation to activate spring boot starter auto configuration
 ```java
 @SpringBootApplication
+@EnableJpaRepositories
 @EnableNakadiProducer
 @EntityScan({"org.zalando.nakadiproducer", "your.apps.base.package"})
 public class Application {


### PR DESCRIPTION
Documented the need to configure JPA repository scanning. This is needed because we use the `@EnableJpaRepositories` annotation in our library ourselfs. If one would not add here, too, it would scan *only* our package structure for repositories.

Will be made more convenient with  issue #6 