### PR TITLE
Some javadoc fixes for the EventPayload interface.

### DIFF
--- a/src/main/java/org/zalando/nakadiproducer/eventlog/EventPayload.java
+++ b/src/main/java/org/zalando/nakadiproducer/eventlog/EventPayload.java
@@ -5,34 +5,42 @@ package org.zalando.nakadiproducer.eventlog;
  * event payload.
  *
  * The object should provide an event type and data type corresponding to the object
- * that represents the data payload itself
+ * that represents the data payload itself.
  *
- * {@link EventPayload::getData} is for returning the data payload itself.
+ * {@link EventPayload#getData} is for returning the data payload itself.
  * This object should be serializable to Json by Jackson ObjectMapper
  */
 public interface EventPayload {
 
     /**
-     * Returns predefined event type sting name that will be attached
-     * to each {@code EventDTO}'s {@code channel} as a {@code topicName} parameter
+     * Returns the event type name that will be used as the
+     * channel name for submission to Nakadi.
+     *
      * @return event type name
      */
     String getEventType();
 
     /**
-     * Returns predefined data type string name that will be attached
-     * to each {@code EventDTO}'s {@code event_payload} as a {@code data_type} parameter
+     * Returns a predefined data type string name that will be used as the {@code data_type} field
+     * for a data change event. ([It is not really clear what it means.](https://github.com/zalando/nakadi/issues/382))
+     * For business events, this is not used (and should be {@code null}.
+     *
      * @return data type name
      */
     String getDataType();
 
     /**
-     * Returns event data payload itself that will be attached to each {@code EventDTO}'s {@code event_payload} as a {@code data} parameter.
+     * Returns the event data payload itself that will be included in
+     * data change events in the {@code data} field.
      * This object should be serializable to Json by Jackson ObjectMapper.
-     * For example if we want to sent an event about creation of some object
-     * then {@code getData} should return the object itself
+     *
+     * For business events, the contents of this object will be used directly as the
+     * event content (just with some metadata added).
+     *
+     * For example if we want to sent an event about creation or update of some object,
+     * this should return the object itself (or a version of it which can be serialized to JSON).
+     *
      * @return event data
      */
     Object getData();
-
 }


### PR DESCRIPTION
Parts of the previous method description were written for a Tarbela producer,
and don't apply here.

This contains some text referring to the situation after #15 is merged (about business events), so it should be merged only after that one.

/cc  @wormangel 