### PR TITLE
Extract event type from payload

### DIFF
--- a/src/main/java/org/zalando/nakadiproducer/eventlog/BusinessEventPayload.java
+++ b/src/main/java/org/zalando/nakadiproducer/eventlog/BusinessEventPayload.java
@@ -8,15 +8,7 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 public class BusinessEventPayload implements EventPayload {
-
-    private String eventType;
-
     private Object data;
-
-    @Override
-    public String getEventType() {
-        return eventType;
-    }
 
     @Override
     public String getDataType() {

--- a/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
+++ b/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
@@ -14,7 +14,7 @@ public interface EventLogWriter {
      *
      */
     @Transactional
-    void fireCreateEvent(EventPayload payload);
+    void fireCreateEvent(String eventType, EventPayload payload);
 
     /**
      * Suppose you want to update some object in a database and also you want to fire an event
@@ -26,7 +26,7 @@ public interface EventLogWriter {
      *
      */
     @Transactional
-    void fireUpdateEvent(EventPayload payload);
+    void fireUpdateEvent(String eventType, EventPayload payload);
 
     /**
      * Suppose you want to remove an object from a database and also you want to fire an event
@@ -38,10 +38,10 @@ public interface EventLogWriter {
      *
      */
     @Transactional
-    void fireDeleteEvent(EventPayload payload);
+    void fireDeleteEvent(String eventType, EventPayload payload);
 
     @Transactional
-    void fireSnapshotEvent(EventPayload payload);
+    void fireSnapshotEvent(String eventType, EventPayload payload);
 
     /**
      * Suppose you want to perform some action on an object in a database and also you want to fire a
@@ -52,5 +52,5 @@ public interface EventLogWriter {
      * @param payload some POJO that can be serialized into JSON (required parameter)
      */
     @Transactional
-    void fireBusinessEvent(EventPayload payload);
+    void fireBusinessEvent(String eventType, EventPayload payload);
 }

--- a/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
+++ b/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
@@ -10,6 +10,7 @@ public interface EventLogWriter {
      * This method will serialize a payload object and will store an event with this payload
      * in a database. After the transaction completed, it will later read the event and publish
      * it to nakadi
+     *  @param eventType the nakadi event type of the event. This is roughly equivalent to an event channel or topic.
      *  @param payload some POJO that can be serialized into JSON (required parameter)
      *
      */
@@ -22,6 +23,7 @@ public interface EventLogWriter {
      * This method will serialize a payload object and will store an event with this payload
      * in a database. After the transaction completed, it will later read the event and publish
      * it to nakadi
+     *  @param eventType the nakadi event type of the event. This is roughly equivalent to an event channel or topic.
      *  @param payload some POJO that can be serialized into JSON (required parameter)
      *
      */
@@ -34,12 +36,25 @@ public interface EventLogWriter {
      * This method will serialize a payload object and will store an event with this payload
      * in a database. After the transaction completed, it will later read the event and publish
      * it to nakadi
+     *  @param eventType the nakadi event type of the event. This is roughly equivalent to an event channel or topic.
      *  @param payload some POJO that can be serialized into JSON (required parameter)
      *
      */
     @Transactional
     void fireDeleteEvent(String eventType, EventPayload payload);
 
+    /**
+     * Suppose you want to notify your consumers about the current state of a resource, even if nothing changed.
+     * Typical use cases include initial replication to new consumers or hotfixes of data inconsistencies between
+     * producer and consumer. Then you can call this method.
+     *
+     * This method will serialize a payload object and will store an event with this payload
+     * in a database. After the transaction completed, it will later read the event and publish
+     * it to nakadi
+     *  @param eventType the nakadi event type of the event. This is roughly equivalent to an event channel or topic.
+     *  @param payload some POJO that can be serialized into JSON (required parameter)
+     *
+     */
     @Transactional
     void fireSnapshotEvent(String eventType, EventPayload payload);
 
@@ -49,6 +64,7 @@ public interface EventLogWriter {
      * This method will serialize a payload object and will store an event with this payload
      * in a database. After the transaction completed, it will later read the event and publish
      * it to nakadi
+     *  @param eventType the nakadi event type of the event. This is roughly equivalent to an event channel or topic.
      * @param payload some POJO that can be serialized into JSON (required parameter)
      */
     @Transactional

--- a/src/main/java/org/zalando/nakadiproducer/eventlog/EventPayload.java
+++ b/src/main/java/org/zalando/nakadiproducer/eventlog/EventPayload.java
@@ -11,14 +11,6 @@ package org.zalando.nakadiproducer.eventlog;
  * This object should be serializable to Json by Jackson ObjectMapper
  */
 public interface EventPayload {
-
-    /**
-     * Returns predefined event type sting name that will be attached
-     * to each {@code EventDTO}'s {@code channel} as a {@code topicName} parameter
-     * @return event type name
-     */
-
-
     /**
      * Returns predefined data type string name that will be attached
      * to each {@code EventDTO}'s {@code event_payload} as a {@code data_type} parameter

--- a/src/main/java/org/zalando/nakadiproducer/eventlog/EventPayload.java
+++ b/src/main/java/org/zalando/nakadiproducer/eventlog/EventPayload.java
@@ -17,7 +17,7 @@ public interface EventPayload {
      * to each {@code EventDTO}'s {@code channel} as a {@code topicName} parameter
      * @return event type name
      */
-    String getEventType();
+
 
     /**
      * Returns predefined data type string name that will be attached

--- a/src/main/java/org/zalando/nakadiproducer/eventlog/SimpleEventPayload.java
+++ b/src/main/java/org/zalando/nakadiproducer/eventlog/SimpleEventPayload.java
@@ -8,17 +8,9 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 public class SimpleEventPayload implements EventPayload {
-
-    private String eventType;
-
     private String dataType;
 
     private Object data;
-
-    @Override
-    public String getEventType() {
-        return eventType;
-    }
 
     @Override
     public String getDataType() {

--- a/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
+++ b/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
@@ -29,42 +29,42 @@ public class EventLogWriterImpl implements EventLogWriter {
 
     @Override
     @Transactional
-    public void fireCreateEvent(final EventPayload payload) {
-        final EventLog eventLog = createEventLog(EventDataOperation.CREATE, payload);
+    public void fireCreateEvent(final String eventType, final EventPayload payload) {
+        final EventLog eventLog = createEventLog(eventType, EventDataOperation.CREATE, payload);
         eventLogRepository.save(eventLog);
     }
 
     @Override
     @Transactional
-    public void fireUpdateEvent(final EventPayload payload) {
-        final EventLog eventLog = createEventLog(EventDataOperation.UPDATE, payload);
+    public void fireUpdateEvent(final String eventType, final EventPayload payload) {
+        final EventLog eventLog = createEventLog(eventType, EventDataOperation.UPDATE, payload);
         eventLogRepository.save(eventLog);
     }
 
     @Override
     @Transactional
-    public void fireDeleteEvent(final EventPayload payload) {
-        final EventLog eventLog = createEventLog(EventDataOperation.DELETE, payload);
+    public void fireDeleteEvent(final String eventType, final EventPayload payload) {
+        final EventLog eventLog = createEventLog(eventType, EventDataOperation.DELETE, payload);
         eventLogRepository.save(eventLog);
     }
 
     @Override
     @Transactional
-    public void fireSnapshotEvent(final EventPayload payload) {
-        final EventLog eventLog = createEventLog(EventDataOperation.SNAPSHOT, payload);
+    public void fireSnapshotEvent(final String eventType, final EventPayload payload) {
+        final EventLog eventLog = createEventLog(eventType, EventDataOperation.SNAPSHOT, payload);
         eventLogRepository.save(eventLog);
     }
 
     @Override
-    public void fireBusinessEvent(EventPayload payload) {
+    public void fireBusinessEvent(final String eventType, EventPayload payload) {
         // data_op doesn't make sense for business events, so just nulify it
-        final EventLog eventLog = createEventLog(null, payload);
+        final EventLog eventLog = createEventLog(eventType, null, payload);
         eventLogRepository.save(eventLog);
     }
 
-    private EventLog createEventLog(final EventDataOperation dataOp, final EventPayload eventPayload) {
+    private EventLog createEventLog(final String eventType, final EventDataOperation dataOp, final EventPayload eventPayload) {
         final EventLog eventLog = new EventLog();
-        eventLog.setEventType(eventPayload.getEventType());
+        eventLog.setEventType(eventType);
         try {
             eventLog.setEventBodyData(objectMapper.writeValueAsString(eventPayload.getData()));
         } catch (final JsonProcessingException e) {

--- a/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventProvider.java
+++ b/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventProvider.java
@@ -45,6 +45,7 @@ public interface SnapshotEventProvider {
     @Getter
     class Snapshot {
         private Object id;
+        private String eventType;
         private EventPayload eventPayload;
     }
 

--- a/src/main/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationService.java
+++ b/src/main/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationService.java
@@ -31,7 +31,7 @@ public class SnapshotCreationService {
             }
 
             for (Snapshot snapshot : snapshots) {
-                eventLogWriter.fireSnapshotEvent(snapshot.getEventPayload());
+                eventLogWriter.fireSnapshotEvent(eventType, snapshot.getEventPayload());
                 lastProcessedId = snapshot.getId();
             }
         } while (true);

--- a/src/test/java/org/zalando/nakadiproducer/TestApplication.java
+++ b/src/test/java/org/zalando/nakadiproducer/TestApplication.java
@@ -38,7 +38,7 @@ public class TestApplication {
                     return Collections.emptyList();
                 } else {
                     return list.stream()
-                               .filter(snapshot -> snapshot.getEventPayload().getEventType().equals(eventType))
+                               .filter(snapshot -> snapshot.getEventType().equals(eventType))
                                .collect(Collectors.toList());
                 }
             }

--- a/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
+++ b/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
@@ -64,7 +64,7 @@ public class EventLogWriterTest {
     @Test
     public void testFireCreateEvent() throws Exception {
 
-        eventLogWriter.fireCreateEvent(eventPayload);
+        eventLogWriter.fireCreateEvent(PUBLISHER_EVENT_TYPE, eventPayload);
         verify(eventLogRepository).save(eventLogCapture.capture());
 
         assertThat(eventLogCapture.getValue().getDataOp(), is("C"));
@@ -80,7 +80,7 @@ public class EventLogWriterTest {
     @Test
     public void testFireUpdateEvent() throws Exception {
 
-        eventLogWriter.fireUpdateEvent(eventPayload);
+        eventLogWriter.fireUpdateEvent(PUBLISHER_EVENT_TYPE, eventPayload);
 
         verify(eventLogRepository).save(eventLogCapture.capture());
 
@@ -97,7 +97,7 @@ public class EventLogWriterTest {
     @Test
     public void testFireDeleteEvent() throws Exception {
 
-        eventLogWriter.fireDeleteEvent(eventPayload);
+        eventLogWriter.fireDeleteEvent(PUBLISHER_EVENT_TYPE, eventPayload);
 
         verify(eventLogRepository).save(eventLogCapture.capture());
 
@@ -113,7 +113,7 @@ public class EventLogWriterTest {
     @Test
     public void testFireSnapshotEvent() throws Exception {
 
-        eventLogWriter.fireSnapshotEvent(eventPayload);
+        eventLogWriter.fireSnapshotEvent(PUBLISHER_EVENT_TYPE, eventPayload);
 
         verify(eventLogRepository).save(eventLogCapture.capture());
 
@@ -131,7 +131,7 @@ public class EventLogWriterTest {
         MockPayload mockPayload = Fixture.mockPayload(1, "mockedcode", true,
                 Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
 
-        eventLogWriter.fireBusinessEvent(Fixture.mockBusinessEventPayload(mockPayload));
+        eventLogWriter.fireBusinessEvent(PUBLISHER_EVENT_TYPE, Fixture.mockBusinessEventPayload(mockPayload));
 
         verify(eventLogRepository).save(eventLogCapture.capture());
 

--- a/src/test/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationServiceTest.java
+++ b/src/test/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationServiceTest.java
@@ -2,6 +2,7 @@ package org.zalando.nakadiproducer.snapshots.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -58,11 +59,11 @@ public class SnapshotCreationServiceTest {
 
     @Test
     public void testCreateSnapshotEvents() {
-        when(snapshotEventProvider.getSnapshot(PUBLISHER_EVENT_TYPE, null)).thenReturn(Collections.singletonList(new Snapshot(1, eventPayload)));
+        when(snapshotEventProvider.getSnapshot(PUBLISHER_EVENT_TYPE, null)).thenReturn(Collections.singletonList(new Snapshot(1, PUBLISHER_EVENT_TYPE, eventPayload)));
 
         eventTransmissionService.createSnapshotEvents(PUBLISHER_EVENT_TYPE);
 
-        verify(eventLogWriter).fireSnapshotEvent(listEventLogCaptor.capture());
+        verify(eventLogWriter).fireSnapshotEvent(eq(PUBLISHER_EVENT_TYPE), listEventLogCaptor.capture());
         assertThat(listEventLogCaptor.getValue(), is(eventPayload));
     }
 
@@ -80,7 +81,7 @@ public class SnapshotCreationServiceTest {
         eventTransmissionService.createSnapshotEvents(PUBLISHER_EVENT_TYPE);
 
         // verify that all returned events got written
-        verify(eventLogWriter, times(5)).fireSnapshotEvent(isA(EventPayload.class));
+        verify(eventLogWriter, times(5)).fireSnapshotEvent(isA(String.class), isA(EventPayload.class));
     }
 
 }

--- a/src/test/java/org/zalando/nakadiproducer/transmission/impl/EventTransmitterIT.java
+++ b/src/test/java/org/zalando/nakadiproducer/transmission/impl/EventTransmitterIT.java
@@ -38,8 +38,8 @@ public class EventTransmitterIT extends BaseMockedExternalCommunicationIT {
     @Test
     public void eventsShouldBeSubmittedToNakadi() throws IOException {
         MockPayload code = Fixture.mockPayload(1, CODE);
-        EventPayload payload = Fixture.mockEventPayload(code, MY_EVENT_TYPE);
-        eventLogWriter.fireCreateEvent(payload);
+        EventPayload payload = Fixture.mockEventPayload(code);
+        eventLogWriter.fireCreateEvent(MY_EVENT_TYPE, payload);
 
         eventTransmitter.sendEvents();
 

--- a/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
+++ b/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
@@ -13,27 +13,17 @@ public class Fixture {
     public static final String PUBLISHER_EVENT_TYPE = "wholesale.some-publisher-change-event";
     public static final String PUBLISHER_DATA_TYPE = "nakadi:some-publisher";
 
-    public static EventPayload mockEventPayload(MockPayload mockPayload, String eventType) {
+    public static EventPayload mockEventPayload(MockPayload mockPayload) {
         return SimpleEventPayload.builder()
                                  .data(mockPayload)
-                                 .eventType(eventType)
                                  .dataType(PUBLISHER_DATA_TYPE)
                                  .build();
     }
 
-    public static EventPayload mockEventPayload(MockPayload mockPayload) {
-        return mockEventPayload(mockPayload, PUBLISHER_EVENT_TYPE);
-    }
-
-    public static EventPayload mockBusinessEventPayload(MockPayload mockPayload, String eventType) {
+    public static EventPayload mockBusinessEventPayload(MockPayload mockPayload) {
         return BusinessEventPayload.builder()
                 .data(mockPayload)
-                .eventType(eventType)
                 .build();
-    }
-
-    public static EventPayload mockBusinessEventPayload(MockPayload mockPayload) {
-        return mockBusinessEventPayload(mockPayload, PUBLISHER_EVENT_TYPE);
     }
 
     public static MockPayload mockPayload(Integer id, String code, Boolean isActive,
@@ -54,7 +44,7 @@ public class Fixture {
     public static List<Snapshot> mockSnapshotList(Integer size) {
         List<Snapshot> list = new ArrayList<>();
         for (int i = 0; i < size; i++) {
-            list.add(new Snapshot(i, mockEventPayload(mockPayload(i + 1, "code" + i, true, mockSubClass("some info " + i), mockSubList(3, "some detail for code" + i)))));
+            list.add(new Snapshot(i, PUBLISHER_EVENT_TYPE, mockEventPayload(mockPayload(i + 1, "code" + i, true, mockSubClass("some info " + i), mockSubList(3, "some detail for code" + i)))));
         }
         return list;
     }


### PR DESCRIPTION
Signature of EventLogWriter changed to accept an event type and a payload. This way we are able to remove the type from inside the payload completely (which makes more sense as it's not part of the data but rather the channel to where we send the data).

EventLog layer untouched. Tests adjusted.

Missing README changes.