### PR TITLE
#4 better flyway config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The Transmitter generates a strictly monotonically increasing event id that can 
 
 Be aware that this library **does neither guarantee that events are sent exactly once, nor that they are sent in the order they have been persisted**. This is not a bug but a design decision that allows us to skip and retry sending events later in case of temporary failures. So make sure that your events are designed to be processed out of order.  To help you in this matter, the library generates a *strictly monotonically increasing event id* (field `metadata/eid` in Nakadi's event object) that can be used to reconstruct the message order.
 
+Please also be aware that, when udating between major releases of this lib, you must not jump over a major release (1.0 -> 3.0). Please always deploy the intermediate major releases at least once. You may of course always setup a fresh system with the newest version.
+
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -46,14 +46,7 @@ public class Application {
 }
 ```
 
-The library uses flyway migrations to set up its own database schema. You must therefore make sure that `classpath:db_nakadiproducer/migrations` is present in a `flyway.locations` property:
-
-```yaml
-flyway.locations: 
-  - classpath:db_nakadiproducer/migrations
-  - classpath:my_db/your_services_migrations
-```
-
+The library uses flyway migrations to set up its own database schema `nakadi_events`.
 ### Nakadi communication configuration
 
 You must tell the library, where it can reach your Nakadi instance:

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>
     <groupId>org.zalando</groupId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>Nakadi Event Producer: Spring Boot Starter</name>
     <description>Spring Boot Auto Configuration for Nakadi event producer</description>
 

--- a/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -128,7 +128,7 @@ public class NakadiProducerAutoConfiguration {
     @PostConstruct
     public void migrateFlyway() {
         Flyway flyway = new Flyway();
-        flyway.setLocations("classpath:db_nakadiproducer/migrations/postgresql");
+        flyway.setLocations("classpath:db_nakadiproducer/migrations");
         flyway.setSchemas("nakadi_events");
         flyway.setDataSource(dataSource);
         flyway.migrate();

--- a/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -131,6 +131,8 @@ public class NakadiProducerAutoConfiguration {
         flyway.setLocations("classpath:db_nakadiproducer/migrations");
         flyway.setSchemas("nakadi_events");
         flyway.setDataSource(dataSource);
+        flyway.setBaselineOnMigrate(true);
+        flyway.setBaselineVersionAsString("2133546886.1.0");
         flyway.migrate();
     }
 }

--- a/src/main/resources/db_nakadiproducer/migrations/V1/V1029384757.1.0__schema.sql
+++ b/src/main/resources/db_nakadiproducer/migrations/V1/V1029384757.1.0__schema.sql
@@ -1,1 +1,0 @@
-CREATE SCHEMA nakadi_events;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -3,8 +3,6 @@ spring:
   jpa:
     show-sql: true
 
-flyway.locations: classpath:db_nakadiproducer/migrations
-
 logging.level:
   org.springframework.web: 'DEBUG'
 


### PR DESCRIPTION
#4 - up until now, we used the flyway instance that was autoconfigured by spring boot. We therefore shared it with the host application leading to namespace clashes and out of order execution errors. We configure our own Flyway instance now. Since flyway, if configured to use its own schema, automatically creates it if it is missing, i removed the creation script.

Upgraded to the next major release because using the old way to configure the application is not compatible any more. Added a note about upgrade path guarantees to the README.md.