### PR TITLE
#5 & #6 Migrating from hibernate/jpa to plain spring JdbcTempates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ Include the library in your `pom.xml`:
 Use `@EnableNakadiProducer` annotation to activate spring boot starter auto configuration:
 ```java
 @SpringBootApplication
-@EnableJpaRepositories
 @EnableNakadiProducer
-@EntityScan({"org.zalando.nakadiproducer", "your.apps.base.package"})
 public class Application {
     public static void main(final String[] args) {
         SpringApplication.run(TestApplication.class, args);

--- a/pom.xml
+++ b/pom.xml
@@ -28,25 +28,31 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
+            <groupId>javax.transaction</groupId>
+            <artifactId>javax.transaction-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.zalando</groupId>
-            <artifactId>tracer-spring-boot-starter</artifactId>
+            <artifactId>fahrschein</artifactId>
+            <version>0.9.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.zalando</groupId>
+            <artifactId>tracer-core</artifactId>
             <version>0.11.2</version>
             <optional>true</optional>
         </dependency>
@@ -57,9 +63,14 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
-            <version>4.0.3</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -91,6 +102,12 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
@@ -104,20 +121,6 @@
             <artifactId>javax.interceptor-api</artifactId>
             <version>1.2</version>
             <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-java8</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.zalando</groupId>
-            <artifactId>fahrschein</artifactId>
-            <version>0.9.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-actuator</artifactId>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -26,8 +26,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.zalando.fahrschein.NakadiClient;
 import org.zalando.nakadiproducer.flowid.FlowIdComponent;
 import org.zalando.nakadiproducer.flowid.NoopFlowIdComponent;
@@ -40,10 +38,8 @@ import org.zalando.nakadiproducer.snapshots.impl.SnapshotEventProviderNotImpleme
 import org.zalando.tracer.Tracer;
 
 @Configuration
-@EnableJpaAuditing
 @Slf4j
 @ComponentScan
-@EnableJpaRepositories
 @ManagementContextConfiguration
 @AutoConfigureAfter(name="org.zalando.tracer.spring.TracerAutoConfiguration")
 public class NakadiProducerAutoConfiguration {

--- a/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
@@ -53,7 +54,7 @@ public class NakadiProducerAutoConfiguration {
         log.error("SnapshotEventProvider interface should be implemented by the service in order to /events/snapshots/{event_type} work");
         return new SnapshotEventProvider() {
             @Override
-            public List<Snapshot> getSnapshot(String eventType, @Nullable Object withIdGreaterThan) {
+            public List<Snapshot> getSnapshot(@Nonnull String eventType, @Nullable Object withIdGreaterThan) {
                 throw new SnapshotEventProviderNotImplementedException();
             }
 

--- a/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLog.java
+++ b/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLog.java
@@ -1,18 +1,5 @@
 package org.zalando.nakadiproducer.eventlog.impl;
 
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.Instant;
-
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,9 +7,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
-@Entity
-@EntityListeners(AuditingEntityListener.class)
-@Table(schema = "nakadi_events", name = "event_log")
+import java.time.Instant;
+
 @ToString
 @Getter
 @Setter
@@ -31,24 +17,13 @@ import lombok.ToString;
 @Builder(toBuilder = true)
 public class EventLog {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
-
     private String eventType;
-
     private String eventBodyData;
-
     private String flowId;
-
-    @CreatedDate
     private Instant created;
-
-    @LastModifiedDate
     private Instant lastModified;
-
     private String lockedBy;
-
     private Instant lockedUntil;
 
 }

--- a/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepository.java
+++ b/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepository.java
@@ -1,17 +1,105 @@
 package org.zalando.nakadiproducer.eventlog.impl;
 
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.stereotype.Component;
 
-public interface EventLogRepository extends JpaRepository<EventLog, Integer> {
+@Component
+public class EventLogRepository {
+    private NamedParameterJdbcTemplate jdbcTemplate;
 
-    Collection<EventLog> findByLockedByAndLockedUntilGreaterThan(String lockedBy, Instant lockedUntil);
+    @Autowired
+    public EventLogRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
 
-    @Modifying
-    @Query("UPDATE EventLog SET lockedBy = ?1, lockedUntil = ?3 where lockedUntil is null or lockedUntil < ?2")
-    void lockSomeMessages(String lockId, Instant now, Instant lockExpires);
+    public Collection<EventLog> findByLockedByAndLockedUntilGreaterThan(String lockedBy, Instant lockedUntil) {
+        Map<String, Object> namedParameterMap = new HashMap<>();
+        namedParameterMap.put("lockedBy", lockedBy);
+        namedParameterMap.put("lockedUntil", toSqlTimestamp(lockedUntil));
+        return jdbcTemplate.query(
+            "SELECT * FROM nakadi_events.event_log where locked_by = :lockedBy and locked_until > :lockedUntil",
+            namedParameterMap,
+            new BeanPropertyRowMapper<>(EventLog.class)
+        );
+    }
+
+    public void lockSomeMessages(String lockId, Instant now, Instant lockExpires) {
+        Map<String, Object> namedParameterMap = new HashMap<>();
+        namedParameterMap.put("lockId", lockId);
+        namedParameterMap.put("now", toSqlTimestamp(now));
+        namedParameterMap.put("lockExpires", toSqlTimestamp(lockExpires));
+        jdbcTemplate.update(
+            "UPDATE nakadi_events.event_log SET locked_by = :lockId, locked_until = :lockExpires where locked_until is null or locked_until < :now",
+            namedParameterMap
+        );
+    }
+
+    public void delete(EventLog eventLog) {
+        Map<String, Object> namedParameterMap = new HashMap<>();
+        namedParameterMap.put("id", eventLog.getId());
+        jdbcTemplate.update(
+            "DELETE FROM nakadi_events.event_log where id = :id",
+            namedParameterMap
+        );
+    }
+
+    public void persist(EventLog eventLog) {
+        Timestamp now = toSqlTimestamp(Instant.now());
+        MapSqlParameterSource namedParameterMap = new MapSqlParameterSource();
+        namedParameterMap.addValue("eventType", eventLog.getEventType());
+        namedParameterMap.addValue("eventBodyData", eventLog.getEventBodyData());
+        namedParameterMap.addValue("flowId", eventLog.getFlowId());
+        namedParameterMap.addValue("created", now);
+        namedParameterMap.addValue("lastModified", now);
+        namedParameterMap.addValue("lockedBy", eventLog.getLockedBy());
+        namedParameterMap.addValue("lockedUntil", eventLog.getLockedUntil());
+        GeneratedKeyHolder generatedKeyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(
+            "INSERT INTO " +
+                "    nakadi_events.event_log " +
+                "    (event_type, event_body_data, flow_id, created, last_modified, locked_by, locked_until) " +
+                "VALUES " +
+                "    (:eventType, :eventBodyData, :flowId, :created, :lastModified, :lockedBy, :lockedUntil)",
+            namedParameterMap,
+            generatedKeyHolder
+        );
+
+        eventLog.setId((Integer) generatedKeyHolder.getKeys().get("id"));
+    }
+
+    private Timestamp toSqlTimestamp(Instant now) {
+        if (now == null) {
+            return null;
+        }
+        return Timestamp.from(now);
+    }
+
+    public void deleteAll() {
+        jdbcTemplate.update("DELETE from nakadi_events.event_log", new HashMap<>());
+    }
+
+    public EventLog findOne(Integer id) {
+        Map<String, Object> namedParameterMap = new HashMap<>();
+        namedParameterMap.put("id", id);
+        try {
+            return jdbcTemplate.queryForObject(
+                "SELECT * FROM nakadi_events.event_log where id = :id",
+                namedParameterMap,
+                new BeanPropertyRowMapper<>(EventLog.class)
+            );
+        } catch (EmptyResultDataAccessException ignored) {
+            return null;
+        }
+    }
 }

--- a/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
+++ b/src/main/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterImpl.java
@@ -35,35 +35,35 @@ public class EventLogWriterImpl implements EventLogWriter {
     @Transactional
     public void fireCreateEvent(final String eventType, final String dataType, final Object data) {
         final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(CREATE.toString(), dataType, data));
-        eventLogRepository.save(eventLog);
+        eventLogRepository.persist(eventLog);
     }
 
     @Override
     @Transactional
     public void fireUpdateEvent(final String eventType, final String dataType, final Object data) {
         final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(UPDATE.toString(), dataType, data));
-        eventLogRepository.save(eventLog);
+        eventLogRepository.persist(eventLog);
     }
 
     @Override
     @Transactional
     public void fireDeleteEvent(final String eventType, final String dataType, final Object data) {
         final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(DELETE.toString(), dataType, data));
-        eventLogRepository.save(eventLog);
+        eventLogRepository.persist(eventLog);
     }
 
     @Override
     @Transactional
     public void fireSnapshotEvent(final String eventType, final String dataType, final Object data) {
         final EventLog eventLog = createEventLog(eventType, new DataChangeEventEnvelope(SNAPSHOT.toString(), dataType, data));
-        eventLogRepository.save(eventLog);
+        eventLogRepository.persist(eventLog);
     }
 
     @Override
     @Transactional
     public void fireBusinessEvent(final String eventType, Object payload) {
         final EventLog eventLog = createEventLog(eventType, payload);
-        eventLogRepository.save(eventLog);
+        eventLogRepository.persist(eventLog);
     }
 
     private EventLog createEventLog(final String eventType, final Object eventPayload) {

--- a/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventProvider.java
+++ b/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventProvider.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
 
 /**
  * The {@code SnapshotEventProvider} interface should be implemented by any
@@ -35,7 +34,7 @@ public interface SnapshotEventProvider {
      * @return list of elements ordered by their id
      * @throws UnknownEventTypeException if {@code eventType} is unknown
      */
-    List<Snapshot> getSnapshot(@NotNull String eventType, @Nullable Object withIdGreaterThan);
+    List<Snapshot> getSnapshot(String eventType, @Nullable Object withIdGreaterThan);
 
     Set<String> getSupportedEventTypes();
 

--- a/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventProvider.java
+++ b/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventProvider.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -34,7 +35,7 @@ public interface SnapshotEventProvider {
      * @return list of elements ordered by their id
      * @throws UnknownEventTypeException if {@code eventType} is unknown
      */
-    List<Snapshot> getSnapshot(String eventType, @Nullable Object withIdGreaterThan);
+    List<Snapshot> getSnapshot(@Nonnull String eventType, @Nullable Object withIdGreaterThan);
 
     Set<String> getSupportedEventTypes();
 

--- a/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryIT.java
+++ b/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogRepositoryIT.java
@@ -43,7 +43,7 @@ public class EventLogRepositoryIT extends BaseMockedExternalCommunicationIT {
         final EventLog eventLog = EventLog.builder().eventBodyData(WAREHOUSE_EVENT_BODY_DATA)
                                                                      .eventType(WAREHOUSE_EVENT_TYPE)
                                                                      .flowId("FLOW_ID").build();
-        eventLogRepository.saveAndFlush(eventLog);
+        eventLogRepository.persist(eventLog);
         id = eventLog.getId();
     }
 

--- a/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
+++ b/src/test/java/org/zalando/nakadiproducer/eventlog/impl/EventLogWriterTest.java
@@ -62,7 +62,7 @@ public class EventLogWriterTest {
     @Test
     public void testFireCreateEvent() throws Exception {
         eventLogWriter.fireCreateEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload);
-        verify(eventLogRepository).save(eventLogCapture.capture());
+        verify(eventLogRepository).persist(eventLogCapture.capture());
 
         assertThat(eventLogCapture.getValue().getEventBodyData(), is(DATA_CHANGE_BODY_DATA.replace("{DATA_OP}", "C")));
         assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
@@ -77,7 +77,7 @@ public class EventLogWriterTest {
 
         eventLogWriter.fireUpdateEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload);
 
-        verify(eventLogRepository).save(eventLogCapture.capture());
+        verify(eventLogRepository).persist(eventLogCapture.capture());
 
         assertThat(eventLogCapture.getValue().getEventBodyData(), is(DATA_CHANGE_BODY_DATA.replace("{DATA_OP}", "U")));
         assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
@@ -92,7 +92,7 @@ public class EventLogWriterTest {
 
         eventLogWriter.fireDeleteEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload);
 
-        verify(eventLogRepository).save(eventLogCapture.capture());
+        verify(eventLogRepository).persist(eventLogCapture.capture());
 
         assertThat(eventLogCapture.getValue().getEventBodyData(), is(DATA_CHANGE_BODY_DATA.replace("{DATA_OP}", "D")));
         assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
@@ -106,7 +106,7 @@ public class EventLogWriterTest {
 
         eventLogWriter.fireSnapshotEvent(PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload);
 
-        verify(eventLogRepository).save(eventLogCapture.capture());
+        verify(eventLogRepository).persist(eventLogCapture.capture());
 
         assertThat(eventLogCapture.getValue().getEventBodyData(), is(DATA_CHANGE_BODY_DATA.replace("{DATA_OP}", "S")));
         assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));
@@ -122,7 +122,7 @@ public class EventLogWriterTest {
 
         eventLogWriter.fireBusinessEvent(PUBLISHER_EVENT_TYPE, mockPayload);
 
-        verify(eventLogRepository).save(eventLogCapture.capture());
+        verify(eventLogRepository).persist(eventLogCapture.capture());
 
         assertThat(eventLogCapture.getValue().getEventBodyData(), is(EVENT_BODY_DATA));
         assertThat(eventLogCapture.getValue().getEventType(), is(PUBLISHER_EVENT_TYPE));

--- a/src/test/resources/db/migration/1__application_db_stub.sql
+++ b/src/test/resources/db/migration/1__application_db_stub.sql
@@ -1,0 +1,3 @@
+CREATE TABLE dummy (
+  id NUMBER NOT NULL
+);


### PR DESCRIPTION
This massively reduces the dependency footprint and solves #5 and #6: No need to configure JpaRepositories and entity scanning in the host application any more. Also removed some more unneccessary pom dependencies.