### PR TITLE
MISC: add eclipse-stuff to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 *.iml
-/target
+*/target/
+.project
+.classpath
+.settings


### PR DESCRIPTION
This just adds some eclipse-specific directories to the .gitignore file.
Also it adapts the path of the ignored target directory, as this is now in each subdirectory.