### PR TITLE
#42 support multiple snapshot event providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ This will only  work if your application has configured spring-boot-actuator
 ```
 and if one or more Spring Beans implement the `org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator` interface. Otherwise, the library will respond with an error message when you request a snapshot creation.
 
-We provide a `SimpleSnapshotEventProvider` to ease bean creation using a more functional Style: 
+We provide a `SimpleSnapshotEventGenerator` to ease bean creation using a more functional Style: 
 ```java
 @Bean
 public SnapshotEventGenerator snapshotEventGenerator(MyService service) {
-    return new SimpleSnapshotEventProvider("event type", service::createSnapshotEvents);
+    return new SimpleSnapshotEventGenerator("event type", service::createSnapshotEvents);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ This will only  work if your application has configured spring-boot-actuator
     <artifactId>spring-boot-starter-actuator</artifactId>
 </dependency>
 ```
-and if one or more Spring Beans implement the `org.zalando.nakadiproducer.snapshots.SnapshotEventProvider` interface. Otherwise, the library will respond with an error message when you request a snapshot creation.
+and if one or more Spring Beans implement the `org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator` interface. Otherwise, the library will respond with an error message when you request a snapshot creation.
 
 We provide a `SimpleSnapshotEventProvider` to ease bean creation using a more functional Style: 
 ```java
 @Bean
-public SnapshotEventProvider snapshotEventProvider(MyService service) {
+public SnapshotEventGenerator snapshotEventGenerator(MyService service) {
     return new SimpleSnapshotEventProvider("event type", service::createSnapshotEvents);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -157,7 +157,15 @@ This will only  work if your application has configured spring-boot-actuator
     <artifactId>spring-boot-starter-actuator</artifactId>
 </dependency>
 ```
-and if it implements the `org.zalando.nakadiproducer.snapshots.SnapshotEventProvider` interface as a Spring Bean. Otherwise, the library will respond with an error message when you request a snapshot creation. 
+and if one or more Spring Beans implement the `org.zalando.nakadiproducer.snapshots.SnapshotEventProvider` interface. Otherwise, the library will respond with an error message when you request a snapshot creation.
+
+We provide a `SimpleSnapshotEventProvider` to ease bean creation using a more functional Style: 
+```java
+@Bean
+public SnapshotEventProvider snapshotEventProvider(MyService service) {
+    return new SimpleSnapshotEventProvider("event type", service::createSnapshotEvents);
+}
+```
 
 ## X-Flow-ID (optional)
 

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>5.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>4.0.2</version>
+        <version>5.0.0</version>
     </parent>
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -31,7 +31,7 @@ import org.zalando.nakadiproducer.eventlog.impl.EventLogWriterImpl;
 import org.zalando.nakadiproducer.flowid.FlowIdComponent;
 import org.zalando.nakadiproducer.flowid.NoopFlowIdComponent;
 import org.zalando.nakadiproducer.flowid.TracerFlowIdComponent;
-import org.zalando.nakadiproducer.snapshots.SnapshotEventProvider;
+import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator;
 import org.zalando.nakadiproducer.snapshots.impl.SnapshotCreationService;
 import org.zalando.nakadiproducer.snapshots.impl.SnapshotEventCreationEndpoint;
 import org.zalando.nakadiproducer.snapshots.impl.SnapshotEventCreationMvcEndpoint;
@@ -118,7 +118,7 @@ public class NakadiProducerAutoConfiguration {
     }
 
     @Bean
-    public SnapshotCreationService snapshotCreationService(Optional<List<SnapshotEventProvider>> snapshotEventProviders, EventLogWriter eventLogWriter) {
+    public SnapshotCreationService snapshotCreationService(Optional<List<SnapshotEventGenerator>> snapshotEventProviders, EventLogWriter eventLogWriter) {
         return new SnapshotCreationService(snapshotEventProviders.orElse(emptyList()), eventLogWriter);
     }
 

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -1,7 +1,6 @@
 package org.zalando.nakadiproducer;
 
 import static java.util.stream.Collectors.toList;
-import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -48,7 +47,6 @@ import org.zalando.tracer.Tracer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
-@Slf4j
 @ComponentScan
 @AutoConfigureAfter(name="org.zalando.tracer.spring.TracerAutoConfiguration")
 public class NakadiProducerAutoConfiguration {

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/TestApplication.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/TestApplication.java
@@ -1,58 +1,11 @@
 package org.zalando.nakadiproducer;
 
-import static org.zalando.nakadiproducer.util.Fixture.PUBLISHER_EVENT_TYPE;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nullable;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.zalando.nakadiproducer.snapshots.SnapshotEventProvider;
-import org.zalando.nakadiproducer.snapshots.SnapshotEventProvider.Snapshot;
-import org.zalando.nakadiproducer.snapshots.UnknownEventTypeException;
-import org.zalando.nakadiproducer.util.Fixture;
 
 @SpringBootApplication
 @EnableNakadiProducer
 public class TestApplication {
-
-    private static volatile List<Snapshot> list = Fixture.mockSnapshotList(6);
-
-    /**
-     * Test implementation of the SnapshotEventProvider interface for integration tests
-     */
-    @Bean
-    public SnapshotEventProvider snapshotEventProvider() {
-        return new SnapshotEventProvider() {
-            @Override
-            public List<Snapshot> getSnapshot(String eventType, @Nullable Object withIdGreaterThan) {
-                if (!Objects.equals(eventType, PUBLISHER_EVENT_TYPE)) {
-                    throw new UnknownEventTypeException(eventType);
-                } else if (withIdGreaterThan != null) {
-                    return Collections.emptyList();
-                } else {
-                    return list.stream()
-                               .filter(snapshot -> snapshot.getEventType().equals(eventType))
-                               .collect(Collectors.toList());
-                }
-            }
-
-            @Override
-            public Set<String> getSupportedEventTypes() {
-                return Collections.singleton(PUBLISHER_EVENT_TYPE);
-            }
-        };
-    }
-
-    public static void setList(List<Snapshot> newList) {
-        list = newList;
-    }
 
     public static void main(final String[] args) {
         SpringApplication.run(TestApplication.class, args);

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGeneratorAutoconfigurationIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGeneratorAutoconfigurationIT.java
@@ -3,6 +3,9 @@ package org.zalando.nakadiproducer.snapshots;
 import static org.junit.Assert.fail;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +27,12 @@ public class SnapshotEventGeneratorAutoconfigurationIT extends BaseMockedExterna
         // expect no exceptions
         snapshotCreationService.createSnapshotEvents("B");
 
+        // expect no exceptions
+        snapshotCreationService.createSnapshotEvents("C");
+
+        // expect no exceptions
+        snapshotCreationService.createSnapshotEvents("D");
+
         try {
             snapshotCreationService.createSnapshotEvents("not defined");
         } catch (UnknownEventTypeException e) {
@@ -44,6 +53,27 @@ public class SnapshotEventGeneratorAutoconfigurationIT extends BaseMockedExterna
         @Bean
         public SnapshotEventGenerator snapshotEventProviderB() {
             return new SimpleSnapshotEventGenerator("B", (x) -> Collections.emptyList());
+        }
+
+        @Bean
+        public SnapshotEventProvider snapshotEventProviderCandD() {
+            return new SnapshotEventProvider() {
+                @Override
+                public List<Snapshot> getSnapshot(String eventType, Object withIdGreaterThan) {
+                    if (!getSupportedEventTypes().contains(eventType)) {
+                        throw new UnknownEventTypeException(eventType);
+                    }
+                    return Collections.emptyList();
+                }
+
+                @Override
+                public Set<String> getSupportedEventTypes() {
+                    HashSet<String> types = new HashSet<>();
+                    types.add("C");
+                    types.add("D");
+                    return types;
+                }
+            };
         }
     }
 }

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGeneratorAutoconfigurationIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGeneratorAutoconfigurationIT.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 import org.zalando.nakadiproducer.BaseMockedExternalCommunicationIT;
 import org.zalando.nakadiproducer.snapshots.impl.SnapshotCreationService;
 
-public class SnapshotEventProviderAutoconfigurationIT extends BaseMockedExternalCommunicationIT {
+public class SnapshotEventGeneratorAutoconfigurationIT extends BaseMockedExternalCommunicationIT {
 
     @Autowired
     SnapshotCreationService snapshotCreationService;
@@ -37,13 +37,13 @@ public class SnapshotEventProviderAutoconfigurationIT extends BaseMockedExternal
     public static class Config {
 
         @Bean
-        public SnapshotEventProvider snapshotEventProviderA() {
-            return new SimpleSnapshotEventProvider("A", (x) -> Collections.emptyList());
+        public SnapshotEventGenerator snapshotEventProviderA() {
+            return new SimpleSnapshotEventGenerator("A", (x) -> Collections.emptyList());
         }
 
         @Bean
-        public SnapshotEventProvider snapshotEventProviderB() {
-            return new SimpleSnapshotEventProvider("B", (x) -> Collections.emptyList());
+        public SnapshotEventGenerator snapshotEventProviderB() {
+            return new SimpleSnapshotEventGenerator("B", (x) -> Collections.emptyList());
         }
     }
 }

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/snapshots/SnapshotEventProviderAutoconfigurationIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/snapshots/SnapshotEventProviderAutoconfigurationIT.java
@@ -1,0 +1,49 @@
+package org.zalando.nakadiproducer.snapshots;
+
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.zalando.nakadiproducer.BaseMockedExternalCommunicationIT;
+import org.zalando.nakadiproducer.snapshots.impl.SnapshotCreationService;
+
+public class SnapshotEventProviderAutoconfigurationIT extends BaseMockedExternalCommunicationIT {
+
+    @Autowired
+    SnapshotCreationService snapshotCreationService;
+
+    @Test
+    public void picksUpDefinedSnapshotEventProviders() {
+        // expect no exceptions
+        snapshotCreationService.createSnapshotEvents("A");
+
+        // expect no exceptions
+        snapshotCreationService.createSnapshotEvents("B");
+
+        try {
+            snapshotCreationService.createSnapshotEvents("not defined");
+        } catch (UnknownEventTypeException e) {
+            return;
+        }
+
+        fail("unknown event type did not result in an exception");
+    }
+
+    @Configuration
+    public static class Config {
+
+        @Bean
+        public SnapshotEventProvider snapshotEventProviderA() {
+            return new SimpleSnapshotEventProvider("A", (x) -> Collections.emptyList());
+        }
+
+        @Bean
+        public SnapshotEventProvider snapshotEventProviderB() {
+            return new SimpleSnapshotEventProvider("B", (x) -> Collections.emptyList());
+        }
+    }
+}

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
@@ -3,7 +3,7 @@ package org.zalando.nakadiproducer.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator.Snapshot;
+import org.zalando.nakadiproducer.snapshots.Snapshot;
 
 public class Fixture {
 

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
@@ -3,7 +3,7 @@ package org.zalando.nakadiproducer.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.zalando.nakadiproducer.snapshots.SnapshotEventProvider.Snapshot;
+import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator.Snapshot;
 
 public class Fixture {
 

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>5.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>nakadi-producer</artifactId>

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>4.0.2</version>
+        <version>5.0.0</version>
     </parent>
 
     <artifactId>nakadi-producer</artifactId>

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/eventlog/EventLogWriter.java
@@ -2,6 +2,8 @@ package org.zalando.nakadiproducer.eventlog;
 
 import javax.transaction.Transactional;
 
+import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator;
+
 /**
  * The main user interface for this library. Autowire an instance of this
  * interface into your service, and call one of the methods whenever you want to
@@ -92,7 +94,7 @@ public interface EventLogWriter {
      * <p>
      * Normally applications don't have to call this themselves, instead they
      * should implement the
-     * {@link org.zalando.nakadiproducer.snapshots.SnapshotEventProvider}
+     * {@link SnapshotEventGenerator}
      * interface to add support for snapshot creation via the actuator endpoint.
      * </p>
      *

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SimpleSnapshotEventGenerator.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SimpleSnapshotEventGenerator.java
@@ -4,27 +4,27 @@ import java.util.List;
 import java.util.function.Function;
 
 /**
- * This is a simple implementation of the {@link SnapshotEventProvider}.
+ * This is a simple implementation of the {@link SnapshotEventGenerator}.
  * It is meant to be used in a functional style
  *
- * @see SnapshotEventProvider
+ * @see SnapshotEventGenerator
  */
-public final class SimpleSnapshotEventProvider implements SnapshotEventProvider {
+public final class SimpleSnapshotEventGenerator implements SnapshotEventGenerator {
     private final String supportedEventType;
     private final Function<Object, List<Snapshot>> getSnapshotFunction;
 
     /**
      * @param supportedEventType the eventType that this SnapShotEventProvider will support
-     * @param snapshotEventFactory a snapshot event factory function conforming to the specification of @link {@link SnapshotEventProvider#getSnapshot(Object)}
+     * @param snapshotEventFactory a snapshot event factory function conforming to the specification of @link {@link SnapshotEventGenerator#generateSnapshots(Object)}
      */
-    public SimpleSnapshotEventProvider(String supportedEventType, Function<Object, List<Snapshot>> snapshotEventFactory) {
+    public SimpleSnapshotEventGenerator(String supportedEventType, Function<Object, List<Snapshot>> snapshotEventFactory) {
         this.supportedEventType = supportedEventType;
         this.getSnapshotFunction = snapshotEventFactory;
     }
 
 
     @Override
-    public List<Snapshot> getSnapshot(Object withIdGreaterThan) {
+    public List<Snapshot> generateSnapshots(Object withIdGreaterThan) {
         return getSnapshotFunction.apply(withIdGreaterThan);
     }
 

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SimpleSnapshotEventProvider.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SimpleSnapshotEventProvider.java
@@ -1,0 +1,35 @@
+package org.zalando.nakadiproducer.snapshots;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * This is a simple implementation of the {@link SnapshotEventProvider}.
+ * It is meant to be used in a functional style
+ *
+ * @see SnapshotEventProvider
+ */
+public final class SimpleSnapshotEventProvider implements SnapshotEventProvider {
+    private final String supportedEventType;
+    private final Function<Object, List<Snapshot>> getSnapshotFunction;
+
+    /**
+     * @param supportedEventType the eventType that this SnapShotEventProvider will support
+     * @param snapshotEventFactory a snapshot event factory function conforming to the specification of @link {@link SnapshotEventProvider#getSnapshot(Object)}
+     */
+    public SimpleSnapshotEventProvider(String supportedEventType, Function<Object, List<Snapshot>> snapshotEventFactory) {
+        this.supportedEventType = supportedEventType;
+        this.getSnapshotFunction = snapshotEventFactory;
+    }
+
+
+    @Override
+    public List<Snapshot> getSnapshot(Object withIdGreaterThan) {
+        return getSnapshotFunction.apply(withIdGreaterThan);
+    }
+
+    @Override
+    public String getSupportedEventType() {
+        return supportedEventType;
+    }
+}

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/Snapshot.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/Snapshot.java
@@ -1,0 +1,13 @@
+package org.zalando.nakadiproducer.snapshots;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class Snapshot {
+    private Object id;
+    private String eventType;
+    private String dataType;
+    private Object data;
+}

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerator.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerator.java
@@ -6,21 +6,23 @@ import lombok.Getter;
 import java.util.List;
 
 /**
- * The {@code SnapshotEventProvider} interface should be implemented by any
+ * The {@code SnapshotEventGenerator} interface should be implemented by any
  * Event Producer that wants to support snapshot events feature. The
- * class must define a method {@code getSnapshot}.
+ * class must define a method {@code generateSnapshots}.
  */
-public interface SnapshotEventProvider {
+public interface SnapshotEventGenerator {
 
     /**
      * Returns a batch of snapshots of given type (event type is an event channel topic name). The implementation may
      * return an arbitrary amount of results, but it must return at least one element if there are entities
      * matching the parameters.
      *
+     * Calling this method must have no side effects.
+     *
      * The library will call your implementation like this:
-     * Request: getSnapshot(null) Response: 1,2,3
-     * Request: getSnapshot(3) Response: 4,5
-     * Request: getSnapshot(5) Response: emptyList
+     * Request: generateSnapshots(null) Response: 1,2,3
+     * Request: generateSnapshots(3) Response: 4,5
+     * Request: generateSnapshots(5) Response: emptyList
      * It is your responsibility to make sure that the returned events are ordered by their id asc and that, given you
      * return a list of events for entities with ids {id1, ..., idN}, there exists no entity with an id between id1 and idN, that
      * is not part of the result.
@@ -29,7 +31,7 @@ public interface SnapshotEventProvider {
      * @param withIdGreaterThan if not null, only events for entities with an id greater than the given one must be returned
      * @return list of elements ordered by their id
      */
-    List<Snapshot> getSnapshot(Object withIdGreaterThan);
+    List<Snapshot> generateSnapshots(Object withIdGreaterThan);
 
     String getSupportedEventType();
 

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerator.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerator.java
@@ -1,8 +1,5 @@
 package org.zalando.nakadiproducer.snapshots;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.util.List;
 
 /**
@@ -34,14 +31,5 @@ public interface SnapshotEventGenerator {
     List<Snapshot> generateSnapshots(Object withIdGreaterThan);
 
     String getSupportedEventType();
-
-    @AllArgsConstructor
-    @Getter
-    class Snapshot {
-        private Object id;
-        private String eventType;
-        private String dataType;
-        private Object data;
-    }
 
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerator.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerator.java
@@ -4,32 +4,46 @@ import java.util.List;
 
 /**
  * The {@code SnapshotEventGenerator} interface should be implemented by any
- * Event Producer that wants to support snapshot events feature. The
- * class must define a method {@code generateSnapshots}.
+ * event producer that wants to support the snapshot events feature. The class
+ * must define a method {@link #generateSnapshots}, as well as {@link #getSupportedEventType()}.
  */
 public interface SnapshotEventGenerator {
 
     /**
-     * Returns a batch of snapshots of given type (event type is an event channel topic name). The implementation may
-     * return an arbitrary amount of results, but it must return at least one element if there are entities
+     * <p>
+     * Returns a batch of snapshots of given type (event type is an event
+     * channel topic name). The implementation may return an arbitrary amount of
+     * results, but it must return at least one element if there are entities
      * matching the parameters.
-     *
+     * </p>
+     * <p>
      * Calling this method must have no side effects.
-     *
+     * </p>
      * The library will call your implementation like this:
-     * Request: generateSnapshots(null) Response: 1,2,3
-     * Request: generateSnapshots(3) Response: 4,5
-     * Request: generateSnapshots(5) Response: emptyList
-     * It is your responsibility to make sure that the returned events are ordered by their id asc and that, given you
-     * return a list of events for entities with ids {id1, ..., idN}, there exists no entity with an id between id1 and idN, that
-     * is not part of the result.
+     * <ul>
+     * <li>Request: generateSnapshots(null), Response: 1,2,3</li>
+     * <li>Request: generateSnapshots(3), Response: 4,5</li>
+     * <li>Request: generateSnapshots(5), Response: emptyList</li>
+     * </ul>
+     * <p>
+     * It is your responsibility to make sure that the returned events are
+     * ordered by their ID ascending and that, given you return a list of events
+     * for entities with IDs {id<sub>1</sub>, ..., id<sub>N</sub>}, there exists
+     * no entity with an ID between id<sub>1</sub> and id<sub>N</sub>, that is
+     * not part of the result.
+     * </p>
      *
-     *
-     * @param withIdGreaterThan if not null, only events for entities with an id greater than the given one must be returned
-     * @return list of elements ordered by their id
+     * @param withIdGreaterThan
+     *            if not null, only events for entities with an ID greater than
+     *            the given one must be returned
+     * @return list of elements (wrapped in Snapshot objects) ordered by their
+     *         ID.
      */
     List<Snapshot> generateSnapshots(Object withIdGreaterThan);
 
+    /**
+     * The name of the event type supported by this snapshot generator.
+     */
     String getSupportedEventType();
 
 }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventProvider.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventProvider.java
@@ -1,0 +1,54 @@
+package org.zalando.nakadiproducer.snapshots;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The {@code SnapshotEventProvider} interface should be implemented by any
+ * Event Producer that wants to support snapshot events feature. The
+ * class must define a method {@code getSnapshot}.
+ *
+ * @deprecated Please use one or more {@link SnapshotEventGenerator} instances instead
+ */
+@Deprecated
+public interface SnapshotEventProvider {
+
+    /**
+     * Returns a batch of snapshots of given type (event type is an event channel topic name). The implementation may
+     * return an arbitrary amount of results, but it must return at least one element if there are entities
+     * matching the parameters.
+     *
+     * The library will call your implementation like this:
+     * Request: getSnapshot(eventType, null) Response: 1,2,3
+     * Request: getSnapshot(eventType, 3) Response: 4,5
+     * Request: getSnapshot(eventType, 5) Response: emptyList
+     * It is your responsibility to make sure that the returned events are ordered by their id asc and that, given you
+     * return a list of events for entities with ids {id1, ..., idN}, there exists no entity with an id between id1 and idN, that
+     * is not part of the result.
+     *
+     *
+     * @param eventType event type to make a snapshot of
+     * @param withIdGreaterThan if not null, only events for entities with an id greater than the given one must be returned
+     * @return list of elements ordered by their id
+     * @throws UnknownEventTypeException if {@code eventType} is unknown
+     */
+    @Deprecated
+    List<Snapshot> getSnapshot(String eventType, Object withIdGreaterThan);
+
+    @Deprecated
+    Set<String> getSupportedEventTypes();
+
+    @AllArgsConstructor
+    @Getter
+    @Deprecated
+    class Snapshot {
+        private Object id;
+        private String eventType;
+        private String dataType;
+        private Object data;
+    }
+
+}

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventProvider.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventProvider.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * The {@code SnapshotEventProvider} interface should be implemented by any
@@ -19,22 +18,20 @@ public interface SnapshotEventProvider {
      * matching the parameters.
      *
      * The library will call your implementation like this:
-     * Request: getSnapshot(eventType, null) Response: 1,2,3
-     * Request: getSnapshot(eventType, 3) Response: 4,5
-     * Request: getSnapshot(eventType, 5) Response: emptyList
+     * Request: getSnapshot(null) Response: 1,2,3
+     * Request: getSnapshot(3) Response: 4,5
+     * Request: getSnapshot(5) Response: emptyList
      * It is your responsibility to make sure that the returned events are ordered by their id asc and that, given you
      * return a list of events for entities with ids {id1, ..., idN}, there exists no entity with an id between id1 and idN, that
      * is not part of the result.
      *
      *
-     * @param eventType event type to make a snapshot of
      * @param withIdGreaterThan if not null, only events for entities with an id greater than the given one must be returned
      * @return list of elements ordered by their id
-     * @throws UnknownEventTypeException if {@code eventType} is unknown
      */
-    List<Snapshot> getSnapshot(String eventType, Object withIdGreaterThan);
+    List<Snapshot> getSnapshot(Object withIdGreaterThan);
 
-    Set<String> getSupportedEventTypes();
+    String getSupportedEventType();
 
     @AllArgsConstructor
     @Getter

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationService.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationService.java
@@ -9,21 +9,21 @@ import java.util.Map;
 import java.util.Set;
 
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
-import org.zalando.nakadiproducer.snapshots.SnapshotEventProvider;
-import org.zalando.nakadiproducer.snapshots.SnapshotEventProvider.Snapshot;
+import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator;
+import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator.Snapshot;
 import org.zalando.nakadiproducer.snapshots.UnknownEventTypeException;
 
 public class SnapshotCreationService {
 
-    private final Map<String, SnapshotEventProvider> snapshotEventProviders;
+    private final Map<String, SnapshotEventGenerator> snapshotEventProviders;
 
     private final EventLogWriter eventLogWriter;
 
-    public SnapshotCreationService(List<SnapshotEventProvider> snapshotEventProviders, EventLogWriter eventLogWriter) {
-        this.snapshotEventProviders = snapshotEventProviders.stream()
-                                                            .collect(
+    public SnapshotCreationService(List<SnapshotEventGenerator> snapshotEventGenerators, EventLogWriter eventLogWriter) {
+        this.snapshotEventProviders = snapshotEventGenerators.stream()
+                                                             .collect(
                                                                 toMap(
-                                                                    SnapshotEventProvider::getSupportedEventType,
+                                                                    SnapshotEventGenerator::getSupportedEventType,
                                                                     identity()
                                                                 )
                                                             );
@@ -31,14 +31,14 @@ public class SnapshotCreationService {
     }
 
     public void createSnapshotEvents(final String eventType) {
-        SnapshotEventProvider snapshotEventProvider = snapshotEventProviders.get(eventType);
-        if (snapshotEventProvider == null) {
+        SnapshotEventGenerator snapshotEventGenerator = snapshotEventProviders.get(eventType);
+        if (snapshotEventGenerator == null) {
             throw new UnknownEventTypeException(eventType);
         }
 
         Object lastProcessedId = null;
         do {
-            List<Snapshot> snapshots = snapshotEventProvider.getSnapshot(lastProcessedId);
+            List<Snapshot> snapshots = snapshotEventGenerator.generateSnapshots(lastProcessedId);
             if (snapshots.isEmpty()) {
                 break;
             }

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationService.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationService.java
@@ -9,8 +9,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
+import org.zalando.nakadiproducer.snapshots.Snapshot;
 import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator;
-import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator.Snapshot;
 import org.zalando.nakadiproducer.snapshots.UnknownEventTypeException;
 
 public class SnapshotCreationService {

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationService.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationService.java
@@ -1,27 +1,44 @@
 package org.zalando.nakadiproducer.snapshots.impl;
 
+import static java.util.Collections.unmodifiableSet;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
 import org.zalando.nakadiproducer.snapshots.SnapshotEventProvider;
 import org.zalando.nakadiproducer.snapshots.SnapshotEventProvider.Snapshot;
+import org.zalando.nakadiproducer.snapshots.UnknownEventTypeException;
 
 public class SnapshotCreationService {
 
-    private final SnapshotEventProvider snapshotEventProvider;
+    private final Map<String, SnapshotEventProvider> snapshotEventProviders;
 
     private final EventLogWriter eventLogWriter;
 
-    public SnapshotCreationService(SnapshotEventProvider snapshotEventProvider, EventLogWriter eventLogWriter) {
-        this.snapshotEventProvider = snapshotEventProvider;
+    public SnapshotCreationService(List<SnapshotEventProvider> snapshotEventProviders, EventLogWriter eventLogWriter) {
+        this.snapshotEventProviders = snapshotEventProviders.stream()
+                                                            .collect(
+                                                                toMap(
+                                                                    SnapshotEventProvider::getSupportedEventType,
+                                                                    identity()
+                                                                )
+                                                            );
         this.eventLogWriter = eventLogWriter;
     }
 
     public void createSnapshotEvents(final String eventType) {
+        SnapshotEventProvider snapshotEventProvider = snapshotEventProviders.get(eventType);
+        if (snapshotEventProvider == null) {
+            throw new UnknownEventTypeException(eventType);
+        }
+
         Object lastProcessedId = null;
         do {
-            List<Snapshot> snapshots = snapshotEventProvider.getSnapshot(eventType, lastProcessedId);
+            List<Snapshot> snapshots = snapshotEventProvider.getSnapshot(lastProcessedId);
             if (snapshots.isEmpty()) {
                 break;
             }
@@ -34,6 +51,6 @@ public class SnapshotCreationService {
     }
 
     public Set<String> getSupportedEventTypes() {
-        return snapshotEventProvider.getSupportedEventTypes();
+        return unmodifiableSet(snapshotEventProviders.keySet());
     }
 }

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationServiceTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationServiceTest.java
@@ -24,8 +24,8 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
+import org.zalando.nakadiproducer.snapshots.Snapshot;
 import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator;
-import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator.Snapshot;
 import org.zalando.nakadiproducer.util.Fixture;
 import org.zalando.nakadiproducer.util.MockPayload;
 

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationServiceTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationServiceTest.java
@@ -24,8 +24,8 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
-import org.zalando.nakadiproducer.snapshots.SnapshotEventProvider;
-import org.zalando.nakadiproducer.snapshots.SnapshotEventProvider.Snapshot;
+import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator;
+import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator.Snapshot;
 import org.zalando.nakadiproducer.util.Fixture;
 import org.zalando.nakadiproducer.util.MockPayload;
 
@@ -33,7 +33,7 @@ import org.zalando.nakadiproducer.util.MockPayload;
 public class SnapshotCreationServiceTest {
 
     @Mock
-    private SnapshotEventProvider snapshotEventProvider;
+    private SnapshotEventGenerator snapshotEventGenerator;
 
     @Mock
     private EventLogWriter eventLogWriter;
@@ -52,13 +52,13 @@ public class SnapshotCreationServiceTest {
     public void setUp() throws Exception {
         eventPayload = Fixture.mockPayload(1, "mockedcode", true,
             Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
-        when(snapshotEventProvider.getSupportedEventType()).thenReturn(PUBLISHER_EVENT_TYPE);
-        snapshotCreationService = new SnapshotCreationService(asList(snapshotEventProvider), eventLogWriter);
+        when(snapshotEventGenerator.getSupportedEventType()).thenReturn(PUBLISHER_EVENT_TYPE);
+        snapshotCreationService = new SnapshotCreationService(asList(snapshotEventGenerator), eventLogWriter);
     }
 
     @Test
     public void testCreateSnapshotEvents() {
-        when(snapshotEventProvider.getSnapshot(null)).thenReturn(Collections.singletonList(new Snapshot(1, PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload)));
+        when(snapshotEventGenerator.generateSnapshots(null)).thenReturn(Collections.singletonList(new Snapshot(1, PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload)));
 
         snapshotCreationService.createSnapshotEvents(PUBLISHER_EVENT_TYPE);
 
@@ -72,9 +72,9 @@ public class SnapshotCreationServiceTest {
         final List<Snapshot> eventPayloads = Fixture.mockSnapshotList(5);
 
         // when snapshot returns 5 item stream
-        when(snapshotEventProvider.getSnapshot(null)).thenReturn(eventPayloads.subList(0, 3));
-        when(snapshotEventProvider.getSnapshot(2)).thenReturn(eventPayloads.subList(3, 5));
-        when(snapshotEventProvider.getSnapshot(4)).thenReturn(Collections.emptyList());
+        when(snapshotEventGenerator.generateSnapshots(null)).thenReturn(eventPayloads.subList(0, 3));
+        when(snapshotEventGenerator.generateSnapshots(2)).thenReturn(eventPayloads.subList(3, 5));
+        when(snapshotEventGenerator.generateSnapshots(4)).thenReturn(Collections.emptyList());
 
         // create a snapshot
         snapshotCreationService.createSnapshotEvents(PUBLISHER_EVENT_TYPE);

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationServiceTest.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/snapshots/impl/SnapshotCreationServiceTest.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadiproducer.snapshots.impl;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.eq;
@@ -20,7 +21,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
@@ -38,8 +38,7 @@ public class SnapshotCreationServiceTest {
     @Mock
     private EventLogWriter eventLogWriter;
 
-    @InjectMocks
-    private SnapshotCreationService eventTransmissionService;
+    private SnapshotCreationService snapshotCreationService;
 
     private MockPayload eventPayload;
 
@@ -53,13 +52,15 @@ public class SnapshotCreationServiceTest {
     public void setUp() throws Exception {
         eventPayload = Fixture.mockPayload(1, "mockedcode", true,
             Fixture.mockSubClass("some info"), Fixture.mockSubList(2, "some detail"));
+        when(snapshotEventProvider.getSupportedEventType()).thenReturn(PUBLISHER_EVENT_TYPE);
+        snapshotCreationService = new SnapshotCreationService(asList(snapshotEventProvider), eventLogWriter);
     }
 
     @Test
     public void testCreateSnapshotEvents() {
-        when(snapshotEventProvider.getSnapshot(PUBLISHER_EVENT_TYPE, null)).thenReturn(Collections.singletonList(new Snapshot(1, PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload)));
+        when(snapshotEventProvider.getSnapshot(null)).thenReturn(Collections.singletonList(new Snapshot(1, PUBLISHER_EVENT_TYPE, PUBLISHER_DATA_TYPE, eventPayload)));
 
-        eventTransmissionService.createSnapshotEvents(PUBLISHER_EVENT_TYPE);
+        snapshotCreationService.createSnapshotEvents(PUBLISHER_EVENT_TYPE);
 
         verify(eventLogWriter).fireSnapshotEvent(eq(PUBLISHER_EVENT_TYPE), eq(PUBLISHER_DATA_TYPE), listEventLogCaptor.capture());
         assertThat(listEventLogCaptor.getValue(), is(eventPayload));
@@ -71,15 +72,15 @@ public class SnapshotCreationServiceTest {
         final List<Snapshot> eventPayloads = Fixture.mockSnapshotList(5);
 
         // when snapshot returns 5 item stream
-        when(snapshotEventProvider.getSnapshot(PUBLISHER_EVENT_TYPE, null)).thenReturn(eventPayloads.subList(0, 3));
-        when(snapshotEventProvider.getSnapshot(PUBLISHER_EVENT_TYPE, 2)).thenReturn(eventPayloads.subList(3, 5));
-        when(snapshotEventProvider.getSnapshot(PUBLISHER_EVENT_TYPE, 4)).thenReturn(Collections.emptyList());
+        when(snapshotEventProvider.getSnapshot(null)).thenReturn(eventPayloads.subList(0, 3));
+        when(snapshotEventProvider.getSnapshot(2)).thenReturn(eventPayloads.subList(3, 5));
+        when(snapshotEventProvider.getSnapshot(4)).thenReturn(Collections.emptyList());
 
         // create a snapshot
-        eventTransmissionService.createSnapshotEvents(PUBLISHER_EVENT_TYPE);
+        snapshotCreationService.createSnapshotEvents(PUBLISHER_EVENT_TYPE);
 
         // verify that all returned events got written
-        verify(eventLogWriter, times(5)).fireSnapshotEvent(isA(String.class), eq(PUBLISHER_DATA_TYPE), isA(MockPayload.class));
+        verify(eventLogWriter, times(5)).fireSnapshotEvent(eq(PUBLISHER_EVENT_TYPE), eq(PUBLISHER_DATA_TYPE), isA(MockPayload.class));
     }
 
 }

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
@@ -3,7 +3,7 @@ package org.zalando.nakadiproducer.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator.Snapshot;
+import org.zalando.nakadiproducer.snapshots.Snapshot;
 
 public class Fixture {
 

--- a/nakadi-producer/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
+++ b/nakadi-producer/src/test/java/org/zalando/nakadiproducer/util/Fixture.java
@@ -3,7 +3,7 @@ package org.zalando.nakadiproducer.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.zalando.nakadiproducer.snapshots.SnapshotEventProvider.Snapshot;
+import org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator.Snapshot;
 
 public class Fixture {
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <artifactId>nakadi-producer-reactor</artifactId>
     <groupId>org.zalando</groupId>
-    <version>5.0.0</version>
+    <version>4.1.0</version>
     <packaging>pom</packaging>
     <name>Nakadi Event Producer Reactor</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <artifactId>nakadi-producer-reactor</artifactId>
     <groupId>org.zalando</groupId>
-    <version>4.0.2</version>
+    <version>5.0.0</version>
     <packaging>pom</packaging>
     <name>Nakadi Event Producer Reactor</name>
 


### PR DESCRIPTION
For #42.

- transformed the `SnapshotEventProvider` interface to `SnapshotEventGenerator`, supporting just one event type
- picking up all  `SnapshotEventGenerator` beans from the spring context (thereby supporting multiple event types)
- added a `SimpleSnapshotEventGenerator` to allow using a functional style of defining the Generators
- the original `SnapshotEventProvider` interface is still supported, but marked as deprecated.


(Original:)
- ~~transformed the `SnapshotEventProvider` interface to support just one event type~~
- ~~picking up not just one, but all  `SnapshotEventProvider` beans from the spring context~~
- ~~added a `SimpleSnapshotEventProvider` to allow using a functional Style of defining the Providers~~
