### PR TITLE
Rename NakadiPublishingClient bean

### DIFF
--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -57,7 +57,7 @@ public class NakadiProducerAutoConfiguration {
     static class FahrscheinNakadiClientConfiguration {
 
         @Bean
-        public NakadiPublishingClient nakadiClient(AccessTokenProvider accessTokenProvider,
+        public NakadiPublishingClient nakadiProducerPublishingClient(AccessTokenProvider accessTokenProvider,
                 @Value("${nakadi-producer.nakadi-base-uri}") URI nakadiBaseUri) {
             return new FahrscheinNakadiPublishingClient(NakadiClient.builder(nakadiBaseUri)
                     .withAccessTokenProvider(accessTokenProvider::getAccessToken).build());


### PR DESCRIPTION
The name `nakadiClient` is not very specific. Therefore it might clash with other libraries and bring complexity/confusion/destruction/chaos.