### PR TITLE
fix boolean operation in flyway migration (&& → ||)

### DIFF
--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/FlywayMigrator.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/FlywayMigrator.java
@@ -64,7 +64,7 @@ public class FlywayMigrator {
 
         if (this.nakadiProducerFlywayDataSource != null) {
             config.dataSource(nakadiProducerFlywayDataSource);
-        } else if (this.flywayProperties != null && flywayProperties.getUser() != null && flywayProperties.getUrl() != null) {
+        } else if (this.flywayProperties != null && (flywayProperties.getUser() != null || flywayProperties.getUrl() != null)) {
             config.dataSource(
                     Optional.ofNullable(this.flywayProperties.getUrl()).orElse(dataSourceProperties.getUrl()),
                     Optional.ofNullable(this.flywayProperties.getUser()).orElse(dataSourceProperties.getUsername()),


### PR DESCRIPTION
[A change in #143](https://github.com/zalando-nakadi/nakadi-producer-spring-boot-starter/pull/143/files#r1049778519) had the effect that it was needed to include a flyway URL when having a separate flyway user (and the other way around). I think this was unintended, maybe caused by the confusing deprecation warning.

This should restore the old behavior.