### PR TITLE
replace SimpleSnapshotEventProducer by static of-methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,18 +298,18 @@ your `application.properties` includes
 ``` 
 management.endpoints.web.exposure.include=snapshot-event-creation,your-other-endpoints,...`
 ```
-and if one or more Spring Beans implement the `org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator` interface.
+and if one or more Spring Beans implement the [`org.zalando.nakadiproducer.snapshots.SnapshotEventGenerator`](nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerator.java) interface.
 (Note that this will automatically work together with the compaction key feature mentioned above,
  if you have registered a compaction key extractor matching the type of the data objects in your snapshots.)
 
 The optional filter specifier of the trigger request will be passed as a string parameter to the
 SnapshotEventGenerator's `generateSnapshots` method and may be null, if none is given.
 
-We provide a `SimpleSnapshotEventGenerator` to ease bean creation using a more functional style:
+The `SnapshotEventGenerator` has static `of` methods to ease bean creation using a more functional style:
 ```java
 @Bean
 public SnapshotEventGenerator snapshotEventGenerator(MyService service) {
-    return new SimpleSnapshotEventGenerator("event type", service::createSnapshotEvents);
+    return SnapshotEventGenerator.of("event type", service::createSnapshotEvents);
 }
 ```
 

--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SimpleSnapshotEventGenerator.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/snapshots/SimpleSnapshotEventGenerator.java
@@ -1,5 +1,7 @@
 package org.zalando.nakadiproducer.snapshots;
 
+import org.springframework.lang.Nullable;
+
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -9,7 +11,9 @@ import java.util.function.Function;
  * meant to be used in a functional style.
  *
  * @see SnapshotEventGenerator
+ * @deprecated Please use the {@link SnapshotEventGenerator#of} methods instead.
  */
+@Deprecated
 public final class SimpleSnapshotEventGenerator implements SnapshotEventGenerator {
     private final String supportedEventType;
     private final BiFunction<Object, String, List<Snapshot>> getSnapshotFunction;
@@ -51,7 +55,7 @@ public final class SimpleSnapshotEventGenerator implements SnapshotEventGenerato
     }
 
     @Override
-    public List<Snapshot> generateSnapshots(Object withIdGreaterThan, String filter) {
+    public List<Snapshot> generateSnapshots(@Nullable Object withIdGreaterThan, String filter) {
         return getSnapshotFunction.apply(withIdGreaterThan, filter);
     }
 


### PR DESCRIPTION
When looking through the README for #166, I noticed that for the compaction key, we use bean creation via `of` methods, while for the snapshot production we have a Simple... implementation.
By now I think the `of` methods are a better style, so this PR introduces them, and deprecates the SimpleSnapshotEventProducer class.


This PR should only be merged when we intend to release a new version soon (as otherwise the README doesn't fit).
I'm not sure this by itself warrants a new version, so we also can just leave it sitting here until we got another feature.

**For the release notes:**

* The `SimpleSnapshotEventGenerator` class is deprecated. Use instead the static `SnapshotEventGenerator.of(...)` methods.