### PR TITLE
Bugfix: no stups token bean if not needed

### DIFF
--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -65,6 +65,7 @@ public class NakadiProducerAutoConfiguration {
         }
 
         @ConditionalOnClass(name = "org.zalando.stups.tokens.Tokens")
+        @ConditionalOnMissingBean({NakadiPublishingClient.class, NakadiClient.class})
         @Configuration
         static class StupsTokenConfiguration {
             @Bean(destroyMethod = "stop")

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/EndToEndTestIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/EndToEndTestIT.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.zalando.nakadiproducer.eventlog.CompactionKeyExtractor;
@@ -39,11 +40,19 @@ public class EndToEndTestIT extends BaseMockedExternalCommunicationIT {
     @Autowired
     private MockNakadiPublishingClient nakadiClient;
 
+    @Autowired
+    ApplicationContext context;
+
     @BeforeEach
     @AfterEach
     public void clearNakadiEvents() {
         eventTransmitter.sendEvents();
         nakadiClient.clearSentEvents();
+    }
+
+    @Test
+    public void noStupsTokenBeanIsSetupWithMockPublishingClient() {
+        assertThat(context.getBeanProvider(StupsTokenComponent.class).getIfAvailable(), is(nullValue()));
     }
 
     @Test

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/NakadiClientContentEncodingIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/NakadiClientContentEncodingIT.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.zalando.fahrschein.http.api.ContentEncoding;
 import org.zalando.fahrschein.http.api.RequestFactory;
 import org.zalando.nakadiproducer.config.EmbeddedDataSourceConfig;
@@ -24,6 +25,11 @@ import static org.hamcrest.Matchers.is;
         classes = { TestApplication.class, EmbeddedDataSourceConfig.class }
 )
 public class NakadiClientContentEncodingIT {
+
+    // Avoid errors in the logs from the AccessTokenRefresher. As we are not actually submitting
+    // to Nakadi, this will never be used.
+    @MockBean
+    private AccessTokenProvider tokenProvider;
 
     @Autowired
     private RequestFactory requestFactory;


### PR DESCRIPTION
When the application already supplies a NakadiPublishingClient
or NakadiClient bean, we don't need our own authentication setup.

This was already meant to be skipped, but I guess we misunderstood
how nested configuration classes work – they don't inherit their
outer classes' conditions.

As an effect, even when one of these beans is already there, a new
StupsTokenComponent bean was created (and the startup failed if that was
not possible e.g. due to missing configuration variables).

* This adds a test which checks that the StupsTokenComponent bean is not created
   when we got the MockPublishingClient bean. (Fails if just running the first commit.)
* We then make the creation of the StupsTokenComponent dependent on missing both beans.

   As an effect, when running the tests we don't get all the error messages about missing
CREDENTIALS_DIR environment variables anymore.

* As a bonus, we also add an AccessTokenProvider @MockBean to NakadiClientEncodingIT (which doesn't have a NakadiPublishingClient) to avoid getting the error messages about CREDENTIALS_DIR here.
