### PR TITLE
Make lock size required

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,9 +422,10 @@ There are three properties for customizing this event locking on transmission:
   considered for transmission. The default is currently 60 seconds but might change in future releases.
 
 * **lock-size** (events): Defines the maximum amount of events which are loaded into memory and published in one run
-  (in one submission per event type). By default, *all* events are loaded into memory. In some future release, this
-  property will become mandatory. This should be set to a value which is not too high so out-of-memory situations
-  are avoided.
+  (in one submission per event type). **This property is mandatory** (even if you disable sending events completely).
+  This should be set to a value which is low enough so out-of-memory situations
+  are avoided (depending on your typical event sizes), and high enough to allow the needed throughput.
+  Using the value 0 will disable the limit completely, but this is not recommended.
 
 Example:
 ```yaml

--- a/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
+++ b/nakadi-producer-spring-boot-starter/src/main/java/org/zalando/nakadiproducer/NakadiProducerAutoConfiguration.java
@@ -150,7 +150,7 @@ public class NakadiProducerAutoConfiguration {
 
     @Bean
     public EventLogRepository eventLogRepository(NamedParameterJdbcTemplate namedParameterJdbcTemplate,
-        @Value("${nakadi-producer.lock-size:0}") int lockSize) {
+        @Value("${nakadi-producer.lock-size}") int lockSize) {
         return new EventLogRepositoryImpl(namedParameterJdbcTemplate, lockSize);
     }
 

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/BaseMockedExternalCommunicationIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/BaseMockedExternalCommunicationIT.java
@@ -8,7 +8,11 @@ import org.zalando.nakadiproducer.config.EmbeddedDataSourceConfig;
 @ActiveProfiles("test")
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-        properties = { "zalando.team.id:alpha-local-testing", "nakadi-producer.scheduled-transmission-enabled:false" },
+        properties = {
+            "zalando.team.id:alpha-local-testing",
+            "nakadi-producer.scheduled-transmission-enabled:false",
+            "nakadi-producer.lock-size:100"
+        },
         classes = { TestApplication.class, EmbeddedDataSourceConfig.class }
 )
 public abstract class BaseMockedExternalCommunicationIT {

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/LockTimeoutIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/LockTimeoutIT.java
@@ -27,7 +27,8 @@ import static org.hamcrest.Matchers.is;
 @SpringBootTest(properties = {
         "nakadi-producer.scheduled-transmission-enabled:false",
         "nakadi-producer.lock-duration:300",
-        "nakadi-producer.lock-duration-buffer:30"})
+        "nakadi-producer.lock-duration-buffer:30",
+        "nakadi-producer.lock-size:100"})
 public class LockTimeoutIT extends BaseMockedExternalCommunicationIT {
     private static final String MY_EVENT_TYPE = "myEventType";
 

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/NakadiClientContentEncodingIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/NakadiClientContentEncodingIT.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.is;
         webEnvironment = SpringBootTest.WebEnvironment.MOCK,
         properties = {
                 "nakadi-producer.scheduled-transmission-enabled:false",
+                "nakadi-producer.lock-size:100",
                 // as we are not defining a mock nakadi client, we need to provide these properties:
                 "nakadi-producer.encoding:ZSTD",
                 "nakadi-producer.nakadi-base-uri:http://nakadi.example.com/",

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/NonNakadiProducerFlywayCallbackIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/NonNakadiProducerFlywayCallbackIT.java
@@ -15,7 +15,12 @@ import org.zalando.nakadiproducer.config.EmbeddedDataSourceConfig;
 @ActiveProfiles("test")
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-        properties = {"zalando.team.id:alpha-local-testing", "nakadi-producer.scheduled-transmission-enabled:false", "spring.flyway.enabled:false"},
+        properties = {
+            "zalando.team.id:alpha-local-testing",
+            "nakadi-producer.scheduled-transmission-enabled:false",
+            "spring.flyway.enabled:false",
+            "nakadi-producer.lock-size:100"
+        },
         classes = {TestApplication.class, EmbeddedDataSourceConfig.class}
 )
 public class NonNakadiProducerFlywayCallbackIT {

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/SubmissionDisabledIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/SubmissionDisabledIT.java
@@ -21,7 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 // no "test" profile, as this would include the mock client.
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-        properties = {"nakadi-producer.submission-enabled:false"},
+        properties = {"nakadi-producer.submission-enabled:false", "nakadi-producer.lock-size:100"},
         classes = { TestApplication.class, EmbeddedDataSourceConfig.class }
 )
 public class SubmissionDisabledIT  {

--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerationWebEndpointIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/snapshots/SnapshotEventGenerationWebEndpointIT.java
@@ -24,6 +24,7 @@ import org.zalando.nakadiproducer.config.EmbeddedDataSourceConfig;
                 "management.security.enabled=false",
                 "zalando.team.id:alpha-local-testing",
                 "nakadi-producer.scheduled-transmission-enabled:false",
+                "nakadi-producer.lock-size:100",
                 "management.endpoints.web.exposure.include:snapshot-event-creation"
         },
         classes = {TestApplication.class, EmbeddedDataSourceConfig.class, SnapshotEventGenerationWebEndpointIT.Config.class}


### PR DESCRIPTION
This is one option from #182, an alternative to #184.

Unfortunately this also makes the lock-size required when the transmission is disabled (which shows in several of the changed tests).

https://github.com/zalando-nakadi/nakadi-producer-spring-boot-starter/issues/182#issuecomment-1716099446 is sketching another alternative, which I didn't yet try to implement.