### PR TITLE
omit metadata.partition_compaction_key if null

### DIFF
--- a/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/NakadiMetadata.java
+++ b/nakadi-producer/src/main/java/org/zalando/nakadiproducer/transmission/impl/NakadiMetadata.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadiproducer.transmission.impl;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 
 import java.time.Instant;
@@ -21,6 +22,7 @@ public class NakadiMetadata {
     private String flowId;
 
     @JsonProperty("partition_compaction_key")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String partitionCompactionKey;
 
 }


### PR DESCRIPTION
In #164, support for compacted event types was introduced.
This was implemented by adding a new nullable property to the NakadiMetadata class.

It turns out that for the value null (which is the default if no compaction key extractor is configured), depending on the configuration of the used object mapper, a `"partition_compaction_key": null` is included in the JSON stream. Nakadi will reject such event submissions for non-compacted event types.

This change is meant to tell Jackson to exclude this property if null, even if the mapper configuration says something else.

TODO: we should get some tests for this.

**For the release notes:**

* #193 Fix a bug when a null compaction key is sent for non-compacted event types.