### PR TITLE
fix flaky LockingIT

### DIFF
--- a/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/LockingIT.java
+++ b/nakadi-producer-spring-boot-starter/src/test/java/org/zalando/nakadiproducer/LockingIT.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.zalando.nakadiproducer.eventlog.EventLogWriter;
 import org.zalando.nakadiproducer.eventlog.impl.EventLog;
+import org.zalando.nakadiproducer.eventlog.impl.EventLogRepository;
 import org.zalando.nakadiproducer.transmission.MockNakadiPublishingClient;
 import org.zalando.nakadiproducer.transmission.impl.EventTransmissionService;
 import org.zalando.nakadiproducer.transmission.impl.EventTransmitter;
@@ -31,6 +32,9 @@ public class LockingIT extends BaseMockedExternalCommunicationIT {
     private EventTransmitter eventTransmitter;
 
     @Autowired
+    private EventLogRepository eventLogRepository;
+
+    @Autowired
     private EventTransmissionService eventTransmissionService;
 
     @Autowired
@@ -41,6 +45,7 @@ public class LockingIT extends BaseMockedExternalCommunicationIT {
     public void clearNakadiEvents() {
         eventTransmitter.sendEvents();
         nakadiClient.clearSentEvents();
+        eventLogRepository.deleteAll();
     }
 
     @Test


### PR DESCRIPTION
For me, LockingIT was always failing, while it worked for others. It was likely depending on the order of tests.
It seems like the `evenTransmitter.sendEvents()` + `nakadiClient.clearSentEvents()` alone doesn't properly manage to clear the event log left from other tests. Clearing the database table directly seems to work.

This is already part of #190, but this makes it available for master (and therefore for the non-spring-boot-3 builds).