### PR TITLE
Release 30.0.0

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.5/apache-maven-3.2.5-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/nakadi-producer-loadtest/pom.xml
+++ b/nakadi-producer-loadtest/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>30.0.0-RC2</version>
+        <version>30.0.0</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer-loadtest/pom.xml
+++ b/nakadi-producer-loadtest/pom.xml
@@ -61,4 +61,19 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.9.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
 </project>

--- a/nakadi-producer-loadtest/pom.xml
+++ b/nakadi-producer-loadtest/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>30.0.0-SNAPSHOT</version>
+        <version>30.0.0-RC2</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -149,29 +149,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.9.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <publishingServerId>central</publishingServerId>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>30.0.0-RC2</version>
+        <version>30.0.0</version>
     </parent>
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>30.0.0-SNAPSHOT</version>
+        <version>30.0.0-RC2</version>
     </parent>
 
     <artifactId>nakadi-producer-spring-boot-starter</artifactId>

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -164,14 +164,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.9.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
                 </configuration>
             </plugin>
         </plugins>

--- a/nakadi-producer-starter-spring-boot-3-test/pom.xml
+++ b/nakadi-producer-starter-spring-boot-3-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>30.0.0-RC2</version>
+        <version>30.0.0</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer-starter-spring-boot-3-test/pom.xml
+++ b/nakadi-producer-starter-spring-boot-3-test/pom.xml
@@ -107,10 +107,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.9.0</version>
+                <extensions>true</extensions>
                 <configuration>
-                    <skip>true</skip>
+                    <skipPublishing>true</skipPublishing>
                 </configuration>
             </plugin>
         </plugins>

--- a/nakadi-producer-starter-spring-boot-3-test/pom.xml
+++ b/nakadi-producer-starter-spring-boot-3-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>30.0.0-SNAPSHOT</version>
+        <version>30.0.0-RC2</version>
     </parent>
 
     <dependencies>

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -141,29 +141,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.9.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <publishingServerId>central</publishingServerId>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -156,14 +156,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.9.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
                 </configuration>
             </plugin>
         </plugins>

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>30.0.0-SNAPSHOT</version>
+        <version>30.0.0-RC2</version>
     </parent>
 
     <artifactId>nakadi-producer</artifactId>

--- a/nakadi-producer/pom.xml
+++ b/nakadi-producer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.zalando</groupId>
         <artifactId>nakadi-producer-reactor</artifactId>
-        <version>30.0.0-RC2</version>
+        <version>30.0.0</version>
     </parent>
 
     <artifactId>nakadi-producer</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <artifactId>nakadi-producer-reactor</artifactId>
     <groupId>org.zalando</groupId>
-    <version>30.0.0-SNAPSHOT</version>
+    <version>30.0.0-RC2</version>
     <packaging>pom</packaging>
     <name>Nakadi Event Producer Reactor</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <artifactId>nakadi-producer-reactor</artifactId>
     <groupId>org.zalando</groupId>
-    <version>30.0.0-RC2</version>
+    <version>30.0.0</version>
     <packaging>pom</packaging>
     <name>Nakadi Event Producer Reactor</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,14 +54,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.9.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
* Bump version numbers to 30.0.0-RC2
* Fix maven Central publishing setup
    * use different plugin
    * configure sign + publish only on top level
    * skip publishing for the test modules
* Bump maven version (as the old one didn't work with the maven central publishing plugin)
* → this is published as 30.0.0-RC2
* Bump version numbers to 30.0.0
* → this is published this as 30.0.0
* bump version numbers again to a new snapshot version